### PR TITLE
Declare textRange

### DIFF
--- a/src/js/modules/clipboard.js
+++ b/src/js/modules/clipboard.js
@@ -204,7 +204,7 @@ Clipboard.prototype.getPasteData = function(e){
 
 
 Clipboard.prototype.copy = function(selector, selectorParams, formatter, formatterParams, internal){
-	var range, sel;
+	var range, sel, textRange;
 	this.blocked = false;
 
 	if(this.mode === true || this.mode === "copy"){


### PR DESCRIPTION
- Fix ASP.NET Core Bundler (BuildBundlerMinifier) problem:
  `Bundler & Minifier error 0: Strict-mode does not allow assignment to undefined variables: textRange`